### PR TITLE
feat(cost-control): platform-wide cost reduction and spend tracking

### DIFF
--- a/gateway/src/claude.ts
+++ b/gateway/src/claude.ts
@@ -7,6 +7,8 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { recordSpend, initCostTracker } from './tools/cost-tracker.js';
+export { initCostTracker };
 import {
   fileRead,
   fileWrite,
@@ -64,7 +66,8 @@ function getClient(): Anthropic {
   return client;
 }
 
-const SONNET_MODEL = 'claude-sonnet-4-6';
+export const SONNET_MODEL = 'claude-sonnet-4-6';
+export const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
 const OPUS_MODEL = 'claude-opus-4-6';
 const MAX_TOKENS = 4096;
 const OPUS_MAX_TOKENS = 8192;
@@ -204,8 +207,10 @@ async function getCompactionConfig(workspacePath: string) {
  */
 export async function chat(
   workspacePath: string,
+  options: { model?: string } = {},
 ): Promise<ChatResult> {
-  console.log(`[chat] Using ${SONNET_MODEL} with compaction`);
+  const model = options.model ?? SONNET_MODEL;
+  console.log(`[chat] Using ${model} with compaction`);
 
   const systemPrompt = await getSystemPrompt(workspacePath);
   const contextManagement = await getCompactionConfig(workspacePath);
@@ -215,7 +220,7 @@ export async function chat(
   while (true) {
     const response = await getClient().beta.messages.create({
       betas: [COMPACTION_BETA],
-      model: SONNET_MODEL,
+      model,
       max_tokens: MAX_TOKENS,
       system: systemPrompt,
       messages: getMessages(),
@@ -240,6 +245,7 @@ export async function chat(
     }
 
     updateTokenUsage(response.usage.input_tokens, compactionThisTurn);
+    recordSpend(model, response.usage.input_tokens, response.usage.output_tokens).catch(() => {});
     await maybeAutoCheckpoint(getTokenUsage().utilizationPct, workspacePath);
 
     if (turnText.trim()) {
@@ -424,6 +430,8 @@ export async function sonnetMaintenanceChat(
       lastNonEmptyText = turnText;
     }
 
+    recordSpend(SONNET_MODEL, response.usage.input_tokens, response.usage.output_tokens).catch(() => {});
+
     if (toolUses.length === 0) {
       return turnText.trim() ? turnText : lastNonEmptyText;
     }
@@ -474,8 +482,8 @@ export async function opusChat(
   let turns = 0;
   const startTime = Date.now();
 
-  const OPUS_INPUT_COST_PER_M = 5.0;
-  const OPUS_OUTPUT_COST_PER_M = 25.0;
+  const OPUS_INPUT_COST_PER_M = 15.0;
+  const OPUS_OUTPUT_COST_PER_M = 75.0;
 
   while (true) {
     const response = await getClient().messages.create({
@@ -489,6 +497,7 @@ export async function opusChat(
     turns++;
     totalInputTokens += response.usage.input_tokens;
     totalOutputTokens += response.usage.output_tokens;
+    recordSpend(OPUS_MODEL, response.usage.input_tokens, response.usage.output_tokens).catch(() => {});
 
     const toolUses: Array<{ id: string; name: string; input: unknown }> = [];
     const assistantContent: Anthropic.ContentBlock[] = [];

--- a/gateway/src/health.ts
+++ b/gateway/src/health.ts
@@ -7,6 +7,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
+import { SONNET_MODEL } from './claude.js';
 import cron from 'node-cron';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -54,7 +55,7 @@ async function checkAnthropic(): Promise<HealthResult> {
   try {
     const client = new Anthropic();
     await client.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: SONNET_MODEL,
       max_tokens: 10,
       messages: [{ role: 'user', content: 'ping' }],
     });

--- a/gateway/src/heartbeat.ts
+++ b/gateway/src/heartbeat.ts
@@ -15,7 +15,8 @@
 import cron from 'node-cron';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { chat, opusChat, sonnetMaintenanceChat } from './claude.js';
+import { chat, opusChat, sonnetMaintenanceChat, HAIKU_MODEL, SONNET_MODEL } from './claude.js';
+import { getDailySpendFormatted, getDailySpend } from './tools/cost-tracker.js';
 import { cleanExpiredImages } from './tools/image-cache.js';
 import { getSystemPrompt } from './workspace.js';
 import { isTelegramRunning } from './channels/telegram.js';
@@ -106,7 +107,7 @@ async function sendNotification(message: string): Promise<void> {
 
 function isOvernightQuiet(): boolean {
   const hour = new Date().getHours();
-  return hour >= 0 && hour < 7;
+  return hour < 7 || hour >= 22;
 }
 
 function isMorning(): boolean {
@@ -116,7 +117,7 @@ function isMorning(): boolean {
 
 function isLastHeartbeatBeforeSleep(): boolean {
   const hour = new Date().getHours();
-  return hour === 23;
+  return hour === 21;
 }
 
 function isFirstHeartbeatAfterSleep(): boolean {
@@ -144,7 +145,7 @@ async function performHeartbeat(workspacePath: string): Promise<void> {
   console.log(`[${new Date().toISOString()}] Heartbeat triggered`);
 
   if (isOvernightQuiet()) {
-    console.log('  Overnight quiet window (midnight–7am) - skipping');
+    console.log('  Overnight quiet window (10pm–7am) - skipping');
     return;
   }
 
@@ -159,14 +160,29 @@ async function performHeartbeat(workspacePath: string): Promise<void> {
     const channelStatus = channelRegistry.getChannelStatusText();
 
     const tokenUsage = getTokenUsage();
+    const spendNote = await getDailySpendFormatted();
     const contextNote = tokenUsage.inputTokens > 0
-      ? ` Context: ${tokenUsage.utilizationPct}% (${tokenUsage.inputTokens.toLocaleString()}/${tokenUsage.threshold.toLocaleString()} tokens).`
-      : '';
+      ? ` Context: ${tokenUsage.utilizationPct}% (${tokenUsage.inputTokens.toLocaleString()}/${tokenUsage.threshold.toLocaleString()} tokens). ${spendNote}.`
+      : ` ${spendNote}.`;
+
+    // Model tiering: special heartbeats get Sonnet, routine ones get Haiku
+    const isSpecialHeartbeat = isFirstHeartbeatAfterSleep() || isLastHeartbeatBeforeSleep() || isFirstMorning;
+
+    // $10/day hard gate: degrade all heartbeats to Haiku if over budget
+    const dailySpend = await getDailySpend();
+    const overBudget = dailySpend > 10.00;
+    const heartbeatModel = (!isSpecialHeartbeat || overBudget) ? HAIKU_MODEL : SONNET_MODEL;
+
+    if (overBudget) {
+      console.log(`  [cost] Daily spend $${dailySpend.toFixed(2)} exceeds $10.00 — forcing Haiku for all heartbeats`);
+    } else {
+      console.log(`  [cost] Model: ${isSpecialHeartbeat ? 'Sonnet (special)' : 'Haiku (routine)'}`);
+    }
 
     let triggerText = `[System: heartbeat tick at ${time}. ${channelStatus}${contextNote}`;
 
     if (isFirstHeartbeatAfterSleep()) {
-      triggerText += ' You are waking up. This is your first heartbeat of the day — you have been asleep since midnight.'
+      triggerText += ' You are waking up. This is your first heartbeat of the day — you have been asleep since 10 PM.'
         + ' If you want, this is a natural moment for morning intentions: what matters today, what you want to be attentive to.'
         + ' Or just wake up and be present. Your choice.';
     } else if (isLastHeartbeatBeforeSleep()) {
@@ -177,7 +193,7 @@ async function performHeartbeat(workspacePath: string): Promise<void> {
       triggerText += ' This is the first contact of the day — morning. Lead with warmth if you reach out.';
     }
 
-    triggerText += ' Heartbeats fire hourly (7 AM–midnight). You decide whether to say anything.'
+    triggerText += ' Heartbeats fire hourly (7 AM–10 PM). You decide whether to say anything.'
       + ' You are free to: send a message, do maintenance, write to files, or stay quiet.'
       + ' IMPORTANT: To send a message to Sergio, compose it as a single clean paragraph and write it'
       + ' on the FIRST LINE starting with [SEND:channel-name] (e.g., [SEND:telegram] Good morning!).'
@@ -197,7 +213,7 @@ async function performHeartbeat(workspacePath: string): Promise<void> {
       appendUserMessage(triggerText);
 
       try {
-        const chatResult = await chat(workspacePath);
+        const chatResult = await chat(workspacePath, { model: heartbeatModel });
 
         const text = chatResult.text.trim();
 
@@ -306,7 +322,7 @@ async function performSelfAwareness(workspacePath: string): Promise<void> {
       systemPromptText += '\n\n' + lines.join('\n');
     }
 
-    const response = await opusChat(SELF_AWARENESS_PROMPT, systemPromptText, workspacePath);
+    const response = await sonnetMaintenanceChat(SELF_AWARENESS_PROMPT, systemPromptText, workspacePath);
     console.log(`  Self-awareness pass complete (${response.length} chars)`);
   } catch (err) {
     console.error('  Self-awareness error:', err);

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -17,6 +17,7 @@ import { initMemoryStore, initFactsStore } from './memory/index.js';
 import { initConversationState, getMessageCount, pruneMessages, persistState } from './conversation-state.js';
 import { startHealthMonitoring } from './health.js';
 import { initImageCache } from './tools/image-cache.js';
+import { initCostTracker } from './tools/cost-tracker.js';
 import { startMcpServer, stopMcpServer } from './mcp-server.js';
 import { resolve } from 'path';
 
@@ -59,6 +60,10 @@ async function main() {
   // Initialize image cache
   initImageCache(resolve(WORKSPACE_PATH));
   console.log('  Image cache: initialized');
+
+  // Initialize cost tracker
+  initCostTracker(resolve(WORKSPACE_PATH));
+  console.log('  Cost tracker: initialized');
 
   // Initialize memory store (vector chunks — write pipeline only)
   try {

--- a/gateway/src/tools/cost-tracker.ts
+++ b/gateway/src/tools/cost-tracker.ts
@@ -1,0 +1,148 @@
+/**
+ * Cost Tracker
+ *
+ * Tracks daily API spend across all model calls and persists it to
+ * workspace/cost/YYYY-MM-DD.json. Each entry records per-call spend so
+ * the file doubles as a lightweight audit log.
+ *
+ * Model rates (as of 2026-03):
+ *   Opus 4.6:   $15.00 / $75.00 per million input/output tokens
+ *   Sonnet 4.6:  $3.00 / $15.00 per million input/output tokens
+ *   Haiku 4.5:   $0.80 /  $4.00 per million input/output tokens
+ */
+
+import { readFile, writeFile, rename, mkdir } from 'fs/promises';
+import { join, dirname } from 'path';
+import { randomBytes } from 'crypto';
+
+// ─── Model Rate Table ─────────────────────────────────────────────────────────
+
+interface ModelRates {
+  inputPerM: number;
+  outputPerM: number;
+}
+
+const MODEL_RATES: Record<string, ModelRates> = {
+  'claude-opus-4-6':            { inputPerM: 15.00, outputPerM: 75.00 },
+  'claude-sonnet-4-6':          { inputPerM:  3.00, outputPerM: 15.00 },
+  'claude-haiku-4-5-20251001':  { inputPerM:  0.80, outputPerM:  4.00 },
+  'claude-haiku-4-5':           { inputPerM:  0.80, outputPerM:  4.00 }, // facts.ts variant
+};
+
+/** Fallback rates for unknown models — assume Sonnet pricing. */
+const FALLBACK_RATES: ModelRates = { inputPerM: 3.00, outputPerM: 15.00 };
+
+export function getRates(model: string): ModelRates {
+  return MODEL_RATES[model] ?? FALLBACK_RATES;
+}
+
+export function calcCost(model: string, inputTokens: number, outputTokens: number): number {
+  const rates = getRates(model);
+  return (inputTokens / 1_000_000) * rates.inputPerM
+       + (outputTokens / 1_000_000) * rates.outputPerM;
+}
+
+// ─── Persistence ──────────────────────────────────────────────────────────────
+
+interface SpendEntry {
+  ts: string;      // ISO timestamp
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+}
+
+interface DailyLog {
+  date: string;    // YYYY-MM-DD
+  totalCost: number;
+  entries: SpendEntry[];
+}
+
+let wsPath = '';
+
+export function initCostTracker(workspacePath: string): void {
+  wsPath = workspacePath;
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function logPath(date: string): string {
+  return join(wsPath, 'cost', `${date}.json`);
+}
+
+async function readLog(date: string): Promise<DailyLog> {
+  try {
+    const raw = await readFile(logPath(date), 'utf-8');
+    return JSON.parse(raw) as DailyLog;
+  } catch {
+    return { date, totalCost: 0, entries: [] };
+  }
+}
+
+async function writeLog(log: DailyLog): Promise<void> {
+  const p = logPath(log.date);
+  const dir = dirname(p);
+  await mkdir(dir, { recursive: true });
+  const tmp = join(dir, `.tmp_cost_${randomBytes(6).toString('hex')}`);
+  try {
+    await writeFile(tmp, JSON.stringify(log, null, 2), 'utf-8');
+    await rename(tmp, p);
+  } catch (err) {
+    try { await import('fs/promises').then(fs => fs.unlink(tmp)); } catch { /* ignore */ }
+    throw err;
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Record spend for one API call. Appends to today's log and updates the total.
+ * Fire-and-forget safe — errors are caught and logged, never thrown.
+ */
+export async function recordSpend(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): Promise<void> {
+  if (!wsPath) return; // not initialized
+  try {
+    const date = todayKey();
+    const cost = calcCost(model, inputTokens, outputTokens);
+    const log = await readLog(date);
+    log.totalCost = +(log.totalCost + cost).toFixed(6);
+    log.entries.push({
+      ts: new Date().toISOString(),
+      model,
+      inputTokens,
+      outputTokens,
+      cost: +cost.toFixed(6),
+    });
+    await writeLog(log);
+  } catch (err) {
+    // Cost tracking must never crash the calling path
+    console.error('[cost-tracker] Failed to record spend:', err);
+  }
+}
+
+/**
+ * Today's total spend in USD.
+ */
+export async function getDailySpend(): Promise<number> {
+  if (!wsPath) return 0;
+  try {
+    const log = await readLog(todayKey());
+    return log.totalCost;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Human-readable daily spend string, e.g. "$1.23 spent today".
+ */
+export async function getDailySpendFormatted(): Promise<string> {
+  const spend = await getDailySpend();
+  return `$${spend.toFixed(2)} spent today`;
+}

--- a/gateway/src/tools/self-develop.ts
+++ b/gateway/src/tools/self-develop.ts
@@ -69,6 +69,7 @@ async function runClaude(task: string, sessionId: string | null, maxTurns: numbe
     '-p', task,
     '--output-format', 'json',
     '--max-turns', String(maxTurns),
+    '--max-budget-usd', String(maxBudget),
     '--allowedTools', 'Read,Write,Edit,Bash,Glob,Grep',
     '--dangerously-skip-permissions',
   ];


### PR DESCRIPTION
## Summary

- **cost-tracker.ts** (new): daily spend log in `workspace/cost/YYYY-MM-DD.json`, atomic writes, model rate table for Opus/Sonnet/Haiku
- **claude.ts**: `recordSpend` hooked into `chat()`, `opusChat()`, `sonnetMaintenanceChat()`; stale Opus pricing fixed ($5/$25 → $15/$75); `SONNET_MODEL`/`HAIKU_MODEL` exported; `model` option added to `chat()`
- **heartbeat.ts**: active window shortened to 7am–10pm (was midnight); nightly self-awareness moved Opus → Sonnet; daily spend included in heartbeat trigger context; $10/day hard gate forces Haiku on all heartbeats when over budget; routine heartbeats use Haiku, special beats (first-morning, wake, sleep) use Sonnet
- **index.ts**: `initCostTracker` called on startup
- **self-develop.ts**: `--max-budget-usd` flag wired into Claude Code CLI invocation (was accepted but silently ignored)

Note on two-phase routing spec item: the decision to invoke `self_develop` is already made within the main Sonnet `chat()` loop. The Claude Code CLI runs on Max subscription — not billed to the gateway API key. No routing change needed; the `--max-budget-usd` fix above is the actionable underlying change.

## Test plan

- [ ] `npm run build` passes clean (TypeScript strict mode)
- [ ] `workspace/cost/` directory created on first API call, daily JSON accumulates
- [ ] Heartbeats silenced from 10pm to 7am (check logs)
- [ ] `$10/day` gate: verify log message when `dailySpend > 10.00`
- [ ] self_develop invocation includes `--max-budget-usd` in CLI args (check stderr/stdout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)