### PR TITLE
fix(self-develop): guardrails — scoped maintenance tools, mutex, audit log

### DIFF
--- a/gateway/src/claude.ts
+++ b/gateway/src/claude.ts
@@ -184,6 +184,23 @@ function getReadOnlyTools(): Anthropic.Tool[] {
 }
 
 /**
+ * Tools for nightly maintenance contexts (reflection, curation, handoff).
+ * Excludes self_develop and send_message — maintenance is for reading,
+ * reflecting, and writing workspace files, not for taking external action.
+ */
+function getMaintenanceTools(): Anthropic.Tool[] {
+  return [
+    ...getToolDefinitions(),
+    ...getWebToolDefinitions(),
+    ...(isCalendarConfigured() ? getCalendarToolDefinitions() : []),
+    getSearchMemoryToolDefinition(),
+    getUpdateStatusToolDefinition(),
+    ...getImageToolDefinitions(),
+    // self_develop and send_message intentionally excluded
+  ];
+}
+
+/**
  * Build the compaction configuration object.
  */
 async function getCompactionConfig(workspacePath: string) {
@@ -392,9 +409,9 @@ export async function sonnetMaintenanceChat(
   userMessage: string,
   systemPrompt: string,
   workspacePath: string,
-  options: { readOnly?: boolean } = {}
+  options: { readOnly?: boolean; maintenanceMode?: boolean } = {}
 ): Promise<string> {
-  console.log(`[chat] Using sonnet-maintenance (${SONNET_MODEL})`);
+  console.log(`[chat] Using sonnet-maintenance (${SONNET_MODEL})${options.maintenanceMode ? ' [maintenance tools only]' : ''}`);
 
   const messages: Anthropic.MessageParam[] = [
     { role: 'user', content: userMessage }
@@ -402,13 +419,19 @@ export async function sonnetMaintenanceChat(
 
   let lastNonEmptyText = '';
 
+  const tools = options.readOnly
+    ? getReadOnlyTools()
+    : options.maintenanceMode
+      ? getMaintenanceTools()
+      : getAllTools();
+
   while (true) {
     const response = await getClient().messages.create({
       model: SONNET_MODEL,
       max_tokens: MAX_TOKENS,
       system: systemPrompt,
       messages,
-      tools: options.readOnly ? getReadOnlyTools() : getAllTools(),
+      tools,
     });
 
     const toolUses: Array<{ id: string; name: string; input: unknown }> = [];
@@ -466,9 +489,9 @@ export async function opusChat(
   userMessage: string,
   systemPrompt: string,
   workspacePath: string,
-  options: { readOnly?: boolean } = {}
+  options: { readOnly?: boolean; maintenanceMode?: boolean } = {}
 ): Promise<string> {
-  const mode = options.readOnly ? 'opus/read-only' : 'opus';
+  const mode = options.readOnly ? 'opus/read-only' : options.maintenanceMode ? 'opus/maintenance' : 'opus';
   console.log(`[chat] Using ${mode} (${OPUS_MODEL})`);
 
   const messages: Anthropic.MessageParam[] = [
@@ -484,13 +507,19 @@ export async function opusChat(
   const OPUS_INPUT_COST_PER_M = 15.0;
   const OPUS_OUTPUT_COST_PER_M = 75.0;
 
+  const tools = options.readOnly
+    ? getReadOnlyTools()
+    : options.maintenanceMode
+      ? getMaintenanceTools()
+      : getAllTools();
+
   while (true) {
     const response = await getClient().messages.create({
       model: OPUS_MODEL,
       max_tokens: OPUS_MAX_TOKENS,
       system: systemPrompt,
       messages,
-      tools: options.readOnly ? getReadOnlyTools() : getAllTools(),
+      tools,
     });
 
     turns++;

--- a/gateway/src/heartbeat.ts
+++ b/gateway/src/heartbeat.ts
@@ -291,7 +291,7 @@ async function performMemoryCuration(workspacePath: string): Promise<void> {
   try {
     const systemPromptBlocks = await getSystemPrompt(workspacePath);
     const systemPromptText = systemPromptBlocks.map(b => b.text).join('\n');
-    const response = await sonnetMaintenanceChat(MEMORY_CURATION_PROMPT, systemPromptText, workspacePath);
+    const response = await sonnetMaintenanceChat(MEMORY_CURATION_PROMPT, systemPromptText, workspacePath, { maintenanceMode: true });
     console.log(`  Curation complete (${response.length} chars). File writes handled via tools.`);
   } catch (err) {
     console.error('  Memory curation error:', err);
@@ -322,7 +322,7 @@ async function performSelfAwareness(workspacePath: string): Promise<void> {
       systemPromptText += '\n\n' + lines.join('\n');
     }
 
-    const response = await sonnetMaintenanceChat(SELF_AWARENESS_PROMPT, systemPromptText, workspacePath);
+    const response = await sonnetMaintenanceChat(SELF_AWARENESS_PROMPT, systemPromptText, workspacePath, { maintenanceMode: true });
     console.log(`  Self-awareness pass complete (${response.length} chars)`);
   } catch (err) {
     console.error('  Self-awareness error:', err);
@@ -410,7 +410,7 @@ async function performHandoff(workspacePath: string): Promise<void> {
       systemPromptText += '\n\n' + lines.join('\n');
     }
 
-    const response = await sonnetMaintenanceChat(HANDOFF_PROMPT, systemPromptText, workspacePath);
+    const response = await sonnetMaintenanceChat(HANDOFF_PROMPT, systemPromptText, workspacePath, { maintenanceMode: true });
     console.log(`  Handoff document complete (${response.length} chars). File write handled via tools.`);
     await writeHandoffStatus(workspacePath, true, handoffFile);
   } catch (err) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -18,6 +18,7 @@ import { initConversationState, getMessageCount, pruneMessages, persistState } f
 import { startHealthMonitoring } from './health.js';
 import { initImageCache } from './tools/image-cache.js';
 import { initCostTracker } from './tools/cost-tracker.js';
+import { initSelfDevelopAuditLog } from './tools/self-develop.js';
 import { startMcpServer, stopMcpServer } from './mcp-server.js';
 import { resolve } from 'path';
 
@@ -64,6 +65,9 @@ async function main() {
   // Initialize cost tracker
   initCostTracker(resolve(WORKSPACE_PATH));
   console.log('  Cost tracker: initialized');
+
+  // Initialize self_develop audit log
+  initSelfDevelopAuditLog(resolve(WORKSPACE_PATH));
 
   // Initialize memory store (vector chunks — write pipeline only)
   try {

--- a/gateway/src/tools/self-develop.ts
+++ b/gateway/src/tools/self-develop.ts
@@ -16,10 +16,11 @@
  */
 
 import { execFile } from 'child_process';
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile, mkdir, rename, unlink } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { promisify } from 'util';
+import { randomBytes } from 'crypto';
 import type Anthropic from '@anthropic-ai/sdk';
 
 const execFileAsync = promisify(execFile);
@@ -32,6 +33,49 @@ const CLAUDE_BIN = process.env.CLAUDE_BIN || '/Users/sergio/.local/bin/claude';
 const DEFAULT_MAX_TURNS = 25;
 const DEFAULT_MAX_BUDGET_USD = 3;
 const EXEC_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+// ─── Mutex ────────────────────────────────────────────────────────────────────
+let running = false;
+
+// ─── Audit log ────────────────────────────────────────────────────────────────
+let auditLogDir = '';
+
+export function initSelfDevelopAuditLog(workspacePath: string): void {
+  auditLogDir = join(resolve(workspacePath), 'cost');
+}
+
+interface AuditEntry {
+  ts: string;
+  task: string;
+  sessionId: string | null;
+  maxTurns: number;
+  maxBudget: number;
+  durationMs: number;
+  resultTurns?: number;
+  resultCost?: number;
+  status: 'completed' | 'failed';
+  error?: string;
+}
+
+async function writeAuditEntry(entry: AuditEntry): Promise<void> {
+  if (!auditLogDir) return;
+  const logPath = join(auditLogDir, 'self-develop-log.json');
+  try {
+    await mkdir(auditLogDir, { recursive: true });
+    let entries: AuditEntry[] = [];
+    try {
+      const raw = await readFile(logPath, 'utf-8');
+      entries = JSON.parse(raw);
+    } catch { /* new file */ }
+    entries.push(entry);
+    const tmp = join(auditLogDir, `.tmp_sdlog_${randomBytes(6).toString('hex')}`);
+    await writeFile(tmp, JSON.stringify(entries, null, 2), 'utf-8');
+    await rename(tmp, logPath);
+  } catch (err) {
+    try { await unlink(join(auditLogDir, `.tmp_sdlog_${randomBytes(6).toString('hex')}`)); } catch { /* ignore */ }
+    console.error('[self_develop] Failed to write audit log:', err);
+  }
+}
 
 interface ClaudeSession {
   session_id: string;
@@ -71,7 +115,6 @@ async function runClaude(task: string, sessionId: string | null, maxTurns: numbe
     '--max-turns', String(maxTurns),
     '--max-budget-usd', String(maxBudget),
     '--allowedTools', 'Read,Write,Edit,Bash,Glob,Grep',
-    '--dangerously-skip-permissions',
   ];
 
   if (sessionId) {
@@ -102,17 +145,17 @@ async function runClaude(task: string, sessionId: string | null, maxTurns: numbe
 export function getSelfDevelopToolDefinition(): Anthropic.Tool {
   return {
     name: 'self_develop',
-    description: `Hand a development task to Claude Code, which has full access to the claire codebase.
+    description: `Hand a development task to Claude Code, which has access to the claire codebase.
 
 Use this to:
 - Fix bugs documented in DEV-NOTES.md
 - Make targeted improvements to the gateway
 - Investigate issues in the codebase
 
-For significant changes, scope the work and get Sergio's approval via Telegram first.
-For small bounded fixes (documented bugs, minor improvements), you can invoke this directly on a quiet heartbeat.
+For significant changes, scope the work and get Sergio's approval first.
+For small bounded fixes (documented bugs, minor improvements), you may invoke this on a quiet heartbeat — but scope the task tightly to specific files and behaviors.
 
-Maintains a persistent session — Claude Code builds up context about the codebase across calls.`,
+Only one self_develop session can run at a time. Maintains a persistent session across calls.`,
     input_schema: {
       type: 'object' as const,
       properties: {
@@ -139,6 +182,14 @@ export async function executeSelfDevelop(input: {
   max_turns?: number;
   max_budget_usd?: number;
 }): Promise<string> {
+  // Mutex — only one self_develop session at a time
+  if (running) {
+    console.log('[self_develop] Rejected — another session is already running');
+    return 'Error: self_develop is already running. Wait for the current session to complete.';
+  }
+
+  running = true;
+  const startTime = Date.now();
   const maxTurns = input.max_turns ?? DEFAULT_MAX_TURNS;
   const maxBudget = input.max_budget_usd ?? DEFAULT_MAX_BUDGET_USD;
 
@@ -150,18 +201,18 @@ export async function executeSelfDevelop(input: {
     console.log('[self_develop] No session found — starting fresh');
   }
 
+  console.log(`[self_develop] Task: ${input.task.slice(0, 200)}${input.task.length > 200 ? '...' : ''}`);
+
   let result: ClaudeCliResult;
   let usedSessionId = existingSessionId;
 
   try {
     result = await runClaude(input.task, existingSessionId, maxTurns, maxBudget);
   } catch (resumeErr) {
-    // execFile errors carry stderr/stdout on the error object itself
     const resumeError = resumeErr as Error & { stderr?: string; stdout?: string; code?: number | string };
     const resumeStderr = resumeError.stderr?.slice(0, 500) || '';
     console.error(`[self_develop] Failed (code=${resumeError.code}): ${resumeError.message}\nStderr: ${resumeStderr}`);
 
-    // Resume failed — session is stale (machine restart, session ended)
     if (existingSessionId) {
       console.log('[self_develop] Resume failed, starting fresh session');
       usedSessionId = null;
@@ -171,12 +222,26 @@ export async function executeSelfDevelop(input: {
         const err = freshErr as Error & { stderr?: string; stdout?: string; code?: number | string };
         const freshStderr = err.stderr?.slice(0, 500) || '';
         console.error(`[self_develop] Fresh session also failed (code=${err.code}): ${err.message}\nStderr: ${freshStderr}`);
+        running = false;
+        await writeAuditEntry({
+          ts: new Date().toISOString(), task: input.task, sessionId: usedSessionId,
+          maxTurns, maxBudget, durationMs: Date.now() - startTime,
+          status: 'failed', error: err.message,
+        });
         return `self_develop failed (fresh session): ${err.message}\n\nStderr: ${freshStderr || 'none'}\nStdout: ${err.stdout?.slice(0, 500) || 'none'}`;
       }
     } else {
+      running = false;
+      await writeAuditEntry({
+        ts: new Date().toISOString(), task: input.task, sessionId: usedSessionId,
+        maxTurns, maxBudget, durationMs: Date.now() - startTime,
+        status: 'failed', error: resumeError.message,
+      });
       return `self_develop failed: ${resumeError.message}\n\nStderr: ${resumeStderr || 'none'}\nStdout: ${resumeError.stdout?.slice(0, 500) || 'none'}`;
     }
   }
+
+  running = false;
 
   // Persist the session ID for next call
   const returnedSessionId = result.session_id;
@@ -190,6 +255,13 @@ export async function executeSelfDevelop(input: {
   const cost = result.cost_usd != null ? ` | cost: $${result.cost_usd.toFixed(3)}` : '';
   const turns = result.num_turns != null ? ` | turns: ${result.num_turns}` : '';
   const sessionNote = returnedSessionId ? `Session: ${returnedSessionId}` : '';
+
+  await writeAuditEntry({
+    ts: new Date().toISOString(), task: input.task, sessionId: returnedSessionId ?? usedSessionId,
+    maxTurns, maxBudget, durationMs: Date.now() - startTime,
+    resultTurns: result.num_turns, resultCost: result.cost_usd,
+    status: 'completed',
+  });
 
   return [
     `## self_develop completed${cost}${turns}`,


### PR DESCRIPTION
## Summary

Closes the three vectors that caused tonight's incident where the nightly Opus pass autonomously invoked self_develop, spawned concurrent CLI sessions with unrestricted filesystem access, and left no audit trail.

**1. Scoped maintenance tool lists** — new `getMaintenanceTools()` in claude.ts excludes self_develop and send_message. All nightly maintenance calls (memory curation, self-awareness, handoff) use this scoped list. Reflection time is for reflecting, not acting.

**2. Remove --dangerously-skip-permissions** — self_develop CLI sessions now use Claude Code's built-in permission system instead of bypassing it. No more macOS as the last line of defense.

**3. Mutex** — only one self_develop session can run at a time. Concurrent invocations are rejected with a clear error message.

**4. Audit log** — every self_develop invocation records task text, timestamps, session ID, duration, turns, cost, and exit status to workspace/cost/self-develop-log.json. Closes the observability gap.

Claire keeps self_develop access during normal heartbeats and conversations. The unified loop stays unified.

## Test plan

- [ ] npm run build passes clean
- [ ] Nightly maintenance passes no longer have self_develop or send_message in tool list (check log: `[maintenance tools only]`)
- [ ] Concurrent self_develop calls rejected (second call returns error)
- [ ] self_develop-log.json created on first invocation with task details
- [ ] self_develop runs without --dangerously-skip-permissions (Claude Code prompts for permissions)

Generated with [Claude Code](https://claude.com/claude-code)