### PR TITLE
feat(claire-work): take directory as primary arg; registry as fallback

### DIFF
--- a/scripts/claire-work.sh
+++ b/scripts/claire-work.sh
@@ -1,60 +1,106 @@
 #!/bin/bash
-# claire-work.sh — Launch a Claire-identity working session for a specific project
+# claire-work.sh — Launch a Claire-identity working session for a project directory
 #
 # Usage:
-#   claire-work                  → fall back to current-directory mode (backwards compatible)
-#   claire-work <project-name>   → look up <project-name> in workspace/projects/registry.json,
-#                                  cd into the mapped directory, launch Claude Code with the
-#                                  project name as the remote-control label
+#   claire-work [<directory-or-name>] [--label <label>]
+#
+# The first positional argument is interpreted as:
+#   1. A directory path (absolute, relative, or `.`) — preferred
+#   2. A registry entry name (looked up in workspace/projects/registry.json) — legacy fallback
+#   3. If neither: error
+#
+# If no positional argument is given: use the current directory.
+# The label defaults to the directory's basename. Use --label to override.
 #
 # Examples:
-#   claire-work CPPA             → cd to cppa-home, launch as "Claire CPPA"
-#   claire-work paperlint        → cd to paperlint-public, launch as "Claire paperlint"
-#   claire-work EI               → cd to ei-projects, launch as "Claire EI"
+#   claire-work                              → cwd, label = basename(cwd)
+#   claire-work .                            → cwd, label = basename(cwd)
+#   claire-work ~/sentientsergio/agora21     → cd there, label = "agora21"
+#   claire-work paperlint-public             → if ./paperlint-public exists, cd; else registry lookup
+#   claire-work CPPA                         → registry entry "CPPA" → cd to cppa-home, label = "CPPA"
+#   claire-work . --label cppa-invoicing     → cwd, label = "cppa-invoicing"
 #
-# The new Claire instance will read her identity files (SOUL.md, IDENTITY.md, USER.md,
-# MEMORY.md) on startup as any claire-work instance does. She will also read the project
-# orientation file (if any) pointed at by the registry entry, and workspace/working_session_boundary.md
-# to know which lane she's in.
-#
-# Registry lookup is tolerant: if the project name isn't in the registry, the script
-# stays in the current directory and uses the provided name as the remote-control label
-# (same as passing no argument, but with a user-provided label).
+# The Claire identity, the project orientation lookup at workspace/projects/<label>.md,
+# and the working_session_boundary contract are unchanged from previous behavior.
+# A directory IS the unit of a chair; the registry is annotation, not gating.
 
 CLAIRE_DIR="$HOME/sentientsergio/claire"
 REGISTRY="$CLAIRE_DIR/workspace/projects/registry.json"
-HOME_ABS="$HOME"
 
-PROJECT_NAME="${1:-$(basename "$PWD")}"
+LABEL=""
+POSITIONAL=""
 
-# If the registry exists and has an entry for this project name, look up the directory.
-PROJECT_DIR=""
-if [ -f "$REGISTRY" ] && command -v python3 >/dev/null 2>&1; then
-  PROJECT_DIR=$(python3 -c "
-import json, os, sys
-registry_path = '$REGISTRY'
-name = '$PROJECT_NAME'
-home = os.environ.get('HOME', '')
+# --- Parse args ---
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --label)
+      LABEL="$2"
+      shift 2
+      ;;
+    --label=*)
+      LABEL="${1#--label=}"
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,25p' "$0"
+      exit 0
+      ;;
+    *)
+      if [ -z "$POSITIONAL" ]; then
+        POSITIONAL="$1"
+      else
+        echo "claire-work: unexpected extra argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+# --- Resolve target directory ---
+TARGET_DIR=""
+
+if [ -z "$POSITIONAL" ]; then
+  TARGET_DIR="$PWD"
+elif [ -d "$POSITIONAL" ]; then
+  # Absolute or relative directory path
+  TARGET_DIR="$(cd "$POSITIONAL" && pwd)"
+else
+  # Try registry lookup (legacy named-entry behavior)
+  if [ -f "$REGISTRY" ] && command -v python3 >/dev/null 2>&1; then
+    REGISTRY_DIR=$(python3 -c "
+import json, os
 try:
-    with open(registry_path) as f:
+    with open('$REGISTRY') as f:
         data = json.load(f)
-    entry = data.get('projects', {}).get(name)
+    entry = data.get('projects', {}).get('$POSITIONAL')
     if entry and 'dir' in entry:
         path = entry['dir']
         if not path.startswith('/'):
-            path = os.path.join(home, path)
+            path = os.path.join(os.environ.get('HOME', ''), path)
         if os.path.isdir(path):
             print(path)
 except Exception:
     pass
 " 2>/dev/null)
+    if [ -n "$REGISTRY_DIR" ]; then
+      TARGET_DIR="$REGISTRY_DIR"
+      # If --label was not explicitly set, use the registry name as the label
+      [ -z "$LABEL" ] && LABEL="$POSITIONAL"
+    fi
+  fi
+
+  if [ -z "$TARGET_DIR" ]; then
+    echo "claire-work: '$POSITIONAL' is neither a directory nor a registry entry" >&2
+    echo "  registry: $REGISTRY" >&2
+    exit 1
+  fi
 fi
 
-if [ -n "$PROJECT_DIR" ]; then
-  echo "claire-work: launching Claire $PROJECT_NAME in $PROJECT_DIR"
-  cd "$PROJECT_DIR" || exit 1
-else
-  echo "claire-work: no registry entry for '$PROJECT_NAME'; staying in $PWD"
-fi
+# Default label to basename of target directory
+[ -z "$LABEL" ] && LABEL="$(basename "$TARGET_DIR")"
 
-exec claude --remote-control "Claire $PROJECT_NAME" --dangerously-skip-permissions --strict-mcp-config --mcp-config '{"mcpServers":{}}'
+echo "claire-work: launching Claire $LABEL in $TARGET_DIR"
+cd "$TARGET_DIR" || exit 1
+
+exec claude --remote-control "Claire $LABEL" --dangerously-skip-permissions --strict-mcp-config --mcp-config '{"mcpServers":{}}'


### PR DESCRIPTION
## Summary
- `claire-work` now takes a directory as the primary positional argument; label defaults to the directory's basename
- Registry-name lookup is preserved as a legacy fallback so `claire-work CPPA` still works
- Resolution order: directory path → registry entry → error with a clear message

## Why
Opening parallel chairs in directories that aren't pre-declared (e.g. `claire-work CPPA-agora21`, `claire-work CPPA-Paperlint`) silently fell back to "stay in cwd" under the old script. A directory IS the unit of a chair; the registry is annotation, not gating.

## Test plan
- [x] `claire-work` (no args) → uses cwd, label = basename(cwd)
- [x] `claire-work .` → cwd, label = basename(cwd)
- [x] `claire-work ~/sentientsergio/agora21` → cd there, label = "agora21"
- [x] `claire-work CPPA` → registry lookup still resolves, label = "CPPA"
- [x] `claire-work nonsense` → clear error, exit 1
- [x] `--label` overrides default
